### PR TITLE
Change component resolution syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for `ember-holygrail-layout`
 
+## v0.3.1
+- [BUGFIX] Use slashes for component lookup instead of dots. Dots break in later versions of ember, slashes were supported all along.
+
 ## v0.3.0
 - [ENHANCEMENT] upgrade to ember 3
 

--- a/addon/components/holygrail-layout/template.hbs
+++ b/addon/components/holygrail-layout/template.hbs
@@ -1,7 +1,7 @@
 {{#if hasBlock}}
   {{yield (hash
-    left=(component 'holygrail-layout.left')
-    center=(component 'holygrail-layout.center')
-    right=(component 'holygrail-layout.right')
+    left=(component 'holygrail-layout/left')
+    center=(component 'holygrail-layout/center')
+    right=(component 'holygrail-layout/right')
   )}}
 {{/if}}


### PR DESCRIPTION
This old `holygrail-layout.left` syntax used to work in older versions of embers, but currently in 3.9 it's failing and the official way was (apparently) always `holygrail-layout/left`. Slashes over dots